### PR TITLE
Make columns optional in config

### DIFF
--- a/src/row.js
+++ b/src/row.js
@@ -13,7 +13,7 @@ class RowComponent extends Component {
             columns = [],
             key, uid, selected, cellClasses, i;
 
-        if (!config.columns || cells.length === 0) {
+        if (!config.columns && cells.length === 0) {
             return console.error('Table can\'t be initialized without set number of columsn and no data!');
         }
 


### PR DESCRIPTION
Instead of checking if both column length in config and in data are non-zero, check if at least one is non-zero